### PR TITLE
Update minimum Aura.DI version to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.5.0",
         "slim/slim": "^3.0@RC",
-        "aura/di": "3.x-dev"
+        "aura/di": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0"


### PR DESCRIPTION
The `-dev` required version for Aura.DI was not allowing the current version of Aura.DI (3.1.0 right now).
